### PR TITLE
Add build and release pipeline from p99-login-proxy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,153 @@
+name: Build
+
+on:
+  push:
+    branches: ["master"]
+    tags: ["v*"]
+  pull_request:
+    branches: ["master"]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to build and publish (e.g. v1.18.0). Leave empty for build-only."
+        required: false
+
+jobs:
+  build:
+    runs-on: windows-latest
+    outputs:
+      zip_name: ${{ steps.artifacts.outputs.zip_name }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: "pip"
+          cache-dependency-path: pyproject.toml
+
+      - name: Stamp version from tag
+        if: startsWith(github.ref, 'refs/tags/v') || github.event.inputs.tag
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ github.event.inputs.tag || github.ref_name }}
+        run: |
+          pip install "semver>=3.0.1"
+          python - <<'PY'
+          import os, re, semver
+          tag = os.environ["RELEASE_TAG"].lstrip("v")
+          v = semver.Version.parse(tag)
+          pre = repr(v.prerelease) if v.prerelease else "None"
+          build = repr(v.build) if v.build else "None"
+          path = "ninjalooter/config.py"
+          with open(path, "r", encoding="utf-8") as f:
+              content = f.read()
+          new_block = (
+              f"SEMVER = semver.VersionInfo(\n"
+              f"    major={v.major},\n"
+              f"    minor={v.minor},\n"
+              f"    patch={v.patch},\n"
+              f"    prerelease={pre},\n"
+              f"    build={build},\n"
+              f")"
+          )
+          content = re.sub(
+              r"SEMVER = semver\.VersionInfo\(.*?\)",
+              new_block,
+              content,
+              flags=re.DOTALL,
+          )
+          with open(path, "w", encoding="utf-8") as f:
+              f.write(content)
+          print(f"Stamped version: {v}")
+          PY
+
+      - name: Build
+        env:
+          TOX_BASEPYTHON: python3.13
+        run: |
+          pip install tox
+          tox -e build
+
+      - name: Resolve artifact names
+        id: artifacts
+        shell: pwsh
+        run: |
+          $zip = Get-ChildItem dist -Filter "ninjalooter-*.zip" | Select-Object -First 1
+          "zip_name=$($zip.Name)" >> $env:GITHUB_OUTPUT
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ninjalooter
+          path: dist/ninjalooter-*.zip
+          if-no-files-found: error
+
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/v') || github.event.inputs.tag
+    permissions:
+      contents: write
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: ninjalooter
+          path: dist
+
+      - name: Detect pre-release tag
+        id: prerelease
+        run: |
+          TAG="${{ github.event.inputs.tag || github.ref_name }}"
+          VERSION="${TAG#v}"
+          if [[ "$VERSION" == *-* ]]; then
+            echo "is_prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.event.inputs.tag || github.ref_name }}
+          name: ${{ github.event.inputs.tag || github.ref_name }}
+          draft: true
+          prerelease: ${{ steps.prerelease.outputs.is_prerelease == 'true' }}
+          files: dist/ninjalooter-*.zip
+
+  notify:
+    runs-on: ubuntu-latest
+    needs: [build, release]
+    if: startsWith(github.ref, 'refs/tags/v') || github.event.inputs.tag
+    steps:
+      - name: Post to Discord
+        env:
+          WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          TAG: ${{ github.event.inputs.tag || github.ref_name }}
+          REPO: ${{ github.repository }}
+          SERVER_URL: ${{ github.server_url }}
+          ZIP_NAME: ${{ needs.build.outputs.zip_name }}
+        run: |
+          if [ -z "$WEBHOOK_URL" ]; then
+            echo "DISCORD_WEBHOOK_URL not set; skipping Discord notification."
+            exit 0
+          fi
+          RELEASE_URL="${SERVER_URL}/${REPO}/releases/tag/${TAG}"
+          ZIP_URL="${SERVER_URL}/${REPO}/releases/download/${TAG}/${ZIP_NAME}"
+          payload=$(jq -n \
+            --arg title "NinjaLooter ${TAG}" \
+            --arg url "$RELEASE_URL" \
+            --arg desc "New release available. [Download ${ZIP_NAME}](${ZIP_URL}) or view all assets on the [release page](${RELEASE_URL})." \
+            '{
+              embeds: [{
+                title: $title,
+                url: $url,
+                description: $desc,
+                color: 5814783
+              }]
+            }')
+          curl -fsS -H "Content-Type: application/json" -X POST -d "$payload" "$WEBHOOK_URL"

--- a/.github/workflows/tox_testing.yml
+++ b/.github/workflows/tox_testing.yml
@@ -3,17 +3,17 @@ name: tox testing
 on: [pull_request]
 
 jobs:
-  build:
+  test:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
-          cache: 'pip'
-      - name: Install Tox and any other packages
+          python-version: "3.13"
+          cache: "pip"
+          cache-dependency-path: pyproject.toml
+      - name: Install Tox
         run: pip install tox
       - name: Run Tox
-        # Run tox using the version of Python in `PATH`
-        run: tox -v -e pep8,coverage
+        run: tox -v -e lint,coverage


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Copies the build and release CI/CD pipeline from p99-login-proxy and adapts it for ninjaLooter. Also fixes the existing `tox_testing.yml` workflow.

## New: `.github/workflows/build.yml`

A GitHub Actions workflow that provides:

### Build job (Windows)
- Triggers on push to `master`, tags (`v*`), pull requests, and manual dispatch
- Sets up Python 3.13 with pip caching
- Stamps the version in `ninjalooter/config.py` from the git tag (on tagged builds)
- Runs `tox -e build` (custom bootloader + PyInstaller)
- Uploads `ninjalooter-*.zip` as a build artifact

### Release job
- Runs only on version tags or manual dispatch with a tag
- Downloads the build artifact
- Creates a draft GitHub Release with the zip attached
- Marks pre-release versions (tags with `-` in the semver) appropriately

### Notify job
- Posts an embed to Discord via webhook when a release is created
- Gracefully skips if `DISCORD_WEBHOOK_URL` secret is not configured

## Fixed: `.github/workflows/tox_testing.yml`

The existing PR testing workflow was broken:
- `actions/checkout@v2` → `@v4`
- `actions/setup-python@v2` → `@v5`
- Python 3.9 → 3.13 (project requires ≥3.10)
- Added `cache-dependency-path: pyproject.toml` (no `requirements.txt` exists)
- `pep8` tox env → `lint` (matches current `tox.ini`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b916039d-bc0a-4623-a1b7-b999f5ecaf2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b916039d-bc0a-4623-a1b7-b999f5ecaf2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

