### PR TITLE
Add standalone eight button page

### DIFF
--- a/stanley-eight.html
+++ b/stanley-eight.html
@@ -1,0 +1,112 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Eight Button</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      font-family: Arial, Helvetica, sans-serif;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    html,
+    body {
+      height: 100%;
+      margin: 0;
+    }
+
+    body {
+      align-items: center;
+      background: #000;
+      display: flex;
+      justify-content: center;
+      min-height: 100%;
+    }
+
+    .eight-button {
+      align-items: center;
+      aspect-ratio: 1;
+      background:
+        radial-gradient(circle at 50% 38%, #ff6666 0 14%, transparent 15%),
+        radial-gradient(circle at 50% 64%, #cc0505 0 16%, transparent 17%),
+        linear-gradient(145deg, #f22929 0%, #b50000 48%, #620000 100%);
+      border: 0.28em solid #2a0000;
+      border-radius: 50%;
+      box-shadow:
+        inset 0 0.22em 0.55em rgba(255, 255, 255, 0.38),
+        inset 0 -0.45em 0.7em rgba(0, 0, 0, 0.55),
+        0 0.45em 0 #2b0000,
+        0 1.1em 2.3em rgba(255, 0, 0, 0.24);
+      color: #fff;
+      cursor: pointer;
+      display: inline-flex;
+      font-size: clamp(4rem, 16vw, 12rem);
+      font-weight: 900;
+      height: clamp(10rem, 36vw, 24rem);
+      justify-content: center;
+      line-height: 1;
+      padding: 0;
+      text-shadow:
+        0 0.045em 0 #5a0000,
+        0 0.08em 0.14em rgba(0, 0, 0, 0.85);
+      transform: translateY(-0.25em);
+      transition: filter 120ms ease, transform 80ms ease, box-shadow 80ms ease;
+      user-select: none;
+      width: clamp(10rem, 36vw, 24rem);
+    }
+
+    .eight-button:hover {
+      filter: brightness(1.08);
+    }
+
+    .eight-button:active,
+    .eight-button.is-playing {
+      box-shadow:
+        inset 0 0.16em 0.45em rgba(255, 255, 255, 0.28),
+        inset 0 -0.2em 0.45em rgba(0, 0, 0, 0.68),
+        0 0.2em 0 #2b0000,
+        0 0.7em 1.7em rgba(255, 0, 0, 0.22);
+      transform: translateY(0);
+    }
+
+    .eight-button:focus-visible {
+      outline: 0.07em solid #fff;
+      outline-offset: 0.12em;
+    }
+  </style>
+</head>
+<body>
+  <button class="eight-button" type="button" aria-label="Play the eight sound">8</button>
+  <audio id="eight-audio" preload="auto">
+    <source src="eight.ogg" type="audio/ogg">
+    <source src="eight.mp3" type="audio/mpeg">
+    <source src="eight.wav" type="audio/wav">
+  </audio>
+
+  <script>
+    const button = document.querySelector(".eight-button");
+    const audio = document.querySelector("#eight-audio");
+
+    button.addEventListener("click", async () => {
+      button.classList.add("is-playing");
+      audio.currentTime = 0;
+
+      try {
+        await audio.play();
+      } catch (error) {
+        console.warn("Add eight.ogg, eight.mp3, or eight.wav next to this page to play the clip.", error);
+        button.classList.remove("is-playing");
+      }
+    });
+
+    audio.addEventListener("ended", () => {
+      button.classList.remove("is-playing");
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a standalone `stanley-eight.html` page with a centered red "8" button on a black background
- Wire the button to replay a local `eight.ogg`, `eight.mp3`, or `eight.wav` clip when clicked

## Testing
- `git diff --check HEAD~1 HEAD`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-92f1ab48-c780-4b99-acfd-e06aef05d584"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-92f1ab48-c780-4b99-acfd-e06aef05d584"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

