### PR TITLE
fix(ui): restore dynamic raid totals in Raid Overview headers

### DIFF
--- a/ninjalooter/raid_overview.py
+++ b/ninjalooter/raid_overview.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from collections import defaultdict
+
+from ninjalooter.models import Player
+
+GUILDLESS_LABEL = "None"
+
+
+def player_visible(player: Player, enabled_guilds: set[str]) -> bool:
+    if player.guild:
+        return player.guild in enabled_guilds
+    return GUILDLESS_LABEL in enabled_guilds
+
+
+def guilds_in_snapshot(snapshot: dict[str, Player]) -> set[str]:
+    guilds: set[str] = set()
+    for player in snapshot.values():
+        if player.guild:
+            guilds.add(player.guild)
+        else:
+            guilds.add(GUILDLESS_LABEL)
+    return guilds
+
+
+def group_players_by_class(
+    snapshot: dict[str, Player], enabled_guilds: set[str]
+) -> dict[str, list[Player]]:
+    by_class: dict[str, list[Player]] = defaultdict(list)
+    for player in snapshot.values():
+        if player_visible(player, enabled_guilds):
+            by_class[player.pclass or "Unknown"].append(player)
+    return by_class
+
+
+def total_filtered_count(by_class: dict[str, list[Player]]) -> int:
+    return sum(len(players) for players in by_class.values())

--- a/ninjalooter/tests/test_raid_overview.py
+++ b/ninjalooter/tests/test_raid_overview.py
@@ -1,0 +1,90 @@
+from ninjalooter import constants
+from ninjalooter import raid_overview
+from ninjalooter.models import Player
+from ninjalooter.tests import base
+
+
+def _snapshot(*players: Player) -> dict[str, Player]:
+    return {player.name: player for player in players}
+
+
+class TestRaidOverviewLogic(base.NLTestBase):
+    def test_total_filtered_count_sums_all_classes(self):
+        snapshot = _snapshot(
+            Player("Tano", constants.WARRIOR, 60, "Castle"),
+            Player("Eran", constants.WARRIOR, 60, "Castle"),
+            Player("Eldar", constants.CLERIC, 60, "Castle"),
+            Player("Moryn", constants.CLERIC, 60, "Kingdom"),
+        )
+        enabled = {"Castle", "Kingdom"}
+        by_class = raid_overview.group_players_by_class(snapshot, enabled)
+
+        self.assertEqual(raid_overview.total_filtered_count(by_class), 4)
+        self.assertEqual(len(by_class[constants.WARRIOR]), 2)
+        self.assertEqual(len(by_class[constants.CLERIC]), 2)
+
+    def test_guild_filter_excludes_unchecked_guilds(self):
+        snapshot = _snapshot(
+            Player("Tano", constants.WARRIOR, 60, "Castle"),
+            Player("Moryn", constants.CLERIC, 60, "Kingdom"),
+        )
+        by_class = raid_overview.group_players_by_class(snapshot, {"Castle"})
+
+        self.assertEqual(raid_overview.total_filtered_count(by_class), 1)
+        self.assertEqual(len(by_class[constants.WARRIOR]), 1)
+        self.assertNotIn(constants.CLERIC, by_class)
+
+    def test_castle_only_example_from_bug_report(self):
+        snapshot = _snapshot(
+            Player("Tano", constants.WARRIOR, 60, "Castle"),
+            Player("Eran", constants.WARRIOR, 60, "Castle"),
+            Player("Nathan", constants.WARRIOR, 60, "Castle"),
+            Player("Arthur", constants.WARRIOR, 60, "Castle"),
+            Player("Eldar", constants.CLERIC, 60, "Castle"),
+            Player("Moryn", constants.CLERIC, 60, "Castle"),
+            Player("Belen", constants.CLERIC, 60, "Castle"),
+            Player("Thora", constants.CLERIC, 60, "Castle"),
+            Player("Alaric", constants.CLERIC, 60, "Castle"),
+            Player("Isadora", constants.CLERIC, 60, "Castle"),
+            Player("Septimus", constants.CLERIC, 60, "Castle"),
+        )
+        by_class = raid_overview.group_players_by_class(snapshot, {"Castle"})
+        total = raid_overview.total_filtered_count(by_class)
+
+        self.assertEqual(total, 11)
+        self.assertEqual(len(by_class[constants.WARRIOR]), 4)
+        self.assertEqual(len(by_class[constants.CLERIC]), 7)
+
+    def test_guildless_players_use_none_label(self):
+        snapshot = _snapshot(
+            Player("Anon", constants.ROGUE, 60, ""),
+            Player("Member", constants.WARRIOR, 60, "Castle"),
+        )
+
+        self.assertEqual(
+            raid_overview.guilds_in_snapshot(snapshot),
+            {"None", "Castle"},
+        )
+
+    def test_guildless_players_visible_when_none_enabled(self):
+        snapshot = _snapshot(
+            Player("Anon", constants.ROGUE, 60, ""),
+            Player("Member", constants.WARRIOR, 60, "Castle"),
+        )
+        by_class = raid_overview.group_players_by_class(
+            snapshot, {raid_overview.GUILDLESS_LABEL}
+        )
+
+        self.assertEqual(raid_overview.total_filtered_count(by_class), 1)
+        self.assertEqual(len(by_class[constants.ROGUE]), 1)
+
+    def test_guildless_players_hidden_when_none_disabled(self):
+        snapshot = _snapshot(Player("Anon", constants.ROGUE, 60, ""))
+        by_class = raid_overview.group_players_by_class(snapshot, {"Castle"})
+
+        self.assertEqual(raid_overview.total_filtered_count(by_class), 0)
+
+    def test_empty_snapshot_has_zero_total(self):
+        by_class = raid_overview.group_players_by_class({}, {"Castle"})
+
+        self.assertEqual(raid_overview.total_filtered_count(by_class), 0)

--- a/ninjalooter/ui/raid_overview_frame.py
+++ b/ninjalooter/ui/raid_overview_frame.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from collections import defaultdict
-
 from PySide6.QtCore import Qt
 from PySide6.QtWidgets import (
     QCheckBox,
@@ -16,25 +14,27 @@ from PySide6.QtWidgets import (
 from ninjalooter import config
 from ninjalooter.app_signals import signals
 from ninjalooter.models import Player
+from ninjalooter.raid_overview import (
+    GUILDLESS_LABEL,
+    group_players_by_class,
+    guilds_in_snapshot,
+    total_filtered_count,
+)
 from ninjalooter.ui.table_model import ColumnDefn, ObjectTableView
 
 COLUMNS = 3
-MAX_POPULATION = 14
-
-
-class _ClassPanel(QWidget):
     """A single class panel: header label, compact table, and watermark for empty."""
 
     TABLE_ROWS = 6  # Fixed row count so all panels are uniform height
 
-    def __init__(self, pclass: str, players: list[Player], total: int, parent=None):
+    def __init__(self, pclass: str, players: list[Player], total_filtered: int, parent=None):
         super().__init__(parent)
         layout = QVBoxLayout(self)
         layout.setContentsMargins(4, 4, 4, 4)
         layout.setSpacing(2)
 
         shown = len(players)
-        header = QLabel(f"<b>{pclass} ({shown} / {MAX_POPULATION})</b>")
+        header = QLabel(f"<b>{pclass} ({shown} / {total_filtered})</b>")
         layout.addWidget(header)
 
         self._table = ObjectTableView(
@@ -113,10 +113,7 @@ class RaidOverviewFrame(QScrollArea):
             if item.widget():
                 item.widget().deleteLater()
 
-        guilds: set[str] = set()
-        for player in self._snapshot.values():
-            if player.guild:
-                guilds.add(player.guild)
+        guilds = guilds_in_snapshot(self._snapshot)
 
         for guild in sorted(guilds):
             cb = QCheckBox(guild)
@@ -141,13 +138,9 @@ class RaidOverviewFrame(QScrollArea):
             if item.widget():
                 item.widget().deleteLater()
 
-        by_class: dict[str, list[Player]] = defaultdict(list)
         enabled_guilds = self._enabled_guilds()
-
-        for player in self._snapshot.values():
-            key = player.pclass or "Unknown"
-            if player.guild in enabled_guilds:
-                by_class[key].append(player)
+        by_class = group_players_by_class(self._snapshot, enabled_guilds)
+        total_filtered = total_filtered_count(by_class)
 
         all_classes = list(config.OVERVIEW_CLASS_ORDER)
         remaining = set(by_class.keys()) - set(all_classes)
@@ -155,8 +148,7 @@ class RaidOverviewFrame(QScrollArea):
 
         for i, pclass in enumerate(all_classes):
             players = by_class.get(pclass, [])
-            total = len([p for p in self._snapshot.values() if (p.pclass or "Unknown") == pclass])
-            panel = _ClassPanel(pclass, players, total, self._grid_container)
+            panel = _ClassPanel(pclass, players, total_filtered, self._grid_container)
             row = i // COLUMNS
             col = i % COLUMNS
             self._grid.addWidget(panel, row, col)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes a PySide6 migration regression where every Raid Overview class header showed `(shown / 14)` because `14` was hardcoded as `MAX_POPULATION` — the number of EverQuest classes, not raid population.

Restores the original wx behavior: each class header shows **filtered class count / total filtered raid population** (e.g. `Warrior (4 / 114)` instead of `Warrior (4 / 14)`).

Also restores guildless player support via a **None** guild filter checkbox, matching the pre-migration behavior.

## Changes

- Remove hardcoded `MAX_POPULATION = 14` from `raid_overview_frame.py`
- Compute `total_filtered` dynamically from guild-filtered players
- Add `ninjalooter/raid_overview.py` with pure counting/filter logic (testable without Qt)
- Add unit tests in `test_raid_overview.py`

## Test plan

- [x] `tox -e py3` — 186 tests pass (7 new raid overview tests)
- [x] Verified Castle-only scenario: 4 Warriors + 7 Clerics → total 11, not 14
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f49ce-c136-7bd4-b2b4-591565c0a9a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f49ce-c136-7bd4-b2b4-591565c0a9a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

